### PR TITLE
refactor(Alert): extract `renderByType` static object

### DIFF
--- a/src/components/atoms/Alert/Alert.tsx
+++ b/src/components/atoms/Alert/Alert.tsx
@@ -15,6 +15,13 @@ export interface AlertProps {
   onClose?: () => void;
 }
 
+const renderByType = {
+  success: <Icon type="success" />,
+  info: <Icon type="info" />,
+  warning: <Icon type="warning" />,
+  error: <Icon type="error" />,
+}
+
 export const Alert: React.FC<AlertProps> = ({
   type = 'success',
   icon = true,
@@ -26,16 +33,6 @@ export const Alert: React.FC<AlertProps> = ({
   children,
 }) => {
   const [closed, setClosed] = React.useState(false);
-
-  const renderByType = React.useMemo(
-    () => ({
-      success: <Icon type="success" />,
-      info: <Icon type="info" />,
-      warning: <Icon type="warning" />,
-      error: <Icon type="error" />,
-    }),
-    [],
-  );
 
   return (
     <div


### PR DESCRIPTION
Previously creating 100 alerts will create also 100 `renderByType` objects
With this changes creating 100 alerts, only 1 `renderByType` object is created